### PR TITLE
Añadir user_id en tablas de gastos e ingresos

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -14,17 +14,22 @@ model Expense {
   category      String
   paymentMethod String   @map("payment_method")
   description   String
+  userId        Int      @map("user_id")
+
+  user User @relation(fields: [userId], references: [id])
 
   @@map("expenses")
 }
 
 model Income {
-  id            Int      @id @default(autoincrement())
-  amount        Int
-  date          DateTime
-  category      String
-  paymentMethod String   @map("payment_method")
-  description   String
+  id          Int      @id @default(autoincrement())
+  amount      Int
+  date        DateTime
+  category    String
+  description String
+  userId      Int      @map("user_id")
+
+  user User @relation(fields: [userId], references: [id])
 
   @@map("incomes")
 }
@@ -35,6 +40,9 @@ model User {
   password String
   email    String @unique
   image    String
+
+  expenses Expense[]
+  incomes  Income[]
 
   @@map("users")
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -2,7 +2,7 @@ import { prisma } from "../src/configuration/prisma.configuration";
 
 async function main() {
   // Usuarios
-  await prisma.user.upsert({
+  const alice = await prisma.user.upsert({
     where: { email: "alice@prisma.io" },
     update: {},
     create: {
@@ -19,8 +19,8 @@ async function main() {
       amount: 5000,
       date: new Date("2025-07-01"),
       category: "Salario",
-      paymentMethod: "Transferencia",
       description: "Sueldo mensual",
+      userId: alice.id,
     },
   });
 
@@ -32,6 +32,7 @@ async function main() {
       category: "Supermercado",
       paymentMethod: "Efectivo",
       description: "Compras de alimentos",
+      userId: alice.id,
     },
   });
 }


### PR DESCRIPTION
Esta rama busca modificar el schema de Prisma para añadir la propiedad _user_id_ a dos tablas y algunos cambios colaterales.

**CAMBIOS:**
- **Se añadió user_id:** Se añadió la propiedad _user_id_ en las tablas **expenses** e **incomes** debido a que cada gasto e ingreso pertenecen a un cierto usuario.
- **Relación entre users, incomes y expenses:** Se creó la relación en _schema.prisma_ de las tablas **users**, **incomes** y **expenses**.
- **Cambios de documentación:** Se cambió la documentación del backend para reflejar las nuevas tablas y se arregló un error en cuanto al comando que debía usarse para generar los datos de prueba.
- **Cambios en seed.ts:** Se modificó el archivo _prisma/seed.ts_ para usar la _id_ del usuario _Alice_ en los gastos e ingresos.