### PR TITLE
test:Agregar pruebas para authMiddleware

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -34,7 +34,7 @@
         "jest": "^30.0.5",
         "prisma": "^6.12.0",
         "swagger-autogen": "^2.23.7",
-        "ts-jest": "^29.4.0",
+        "ts-jest": "^29.4.1",
         "ts-node-dev": "^2.0.0"
       }
     },
@@ -181,14 +181,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -321,13 +321,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.28.2"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -591,18 +591,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
+        "@babel/generator": "^7.28.3",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
+        "@babel/parser": "^7.28.3",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/types": "^7.28.2",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1823,13 +1823,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/babel-jest": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.5.tgz",
@@ -2515,22 +2508,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.190",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.190.tgz",
@@ -2788,39 +2765,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3061,6 +3005,28 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3419,25 +3385,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jest": {
@@ -4620,6 +4567,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-addon-api": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
@@ -5713,15 +5667,15 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
-      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
+      "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
@@ -5763,19 +5717,6 @@
         "jest-util": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ts-jest/node_modules/type-fest": {
@@ -5935,6 +5876,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
@@ -6081,6 +6036,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -41,7 +41,7 @@
     "jest": "^30.0.5",
     "prisma": "^6.12.0",
     "swagger-autogen": "^2.23.7",
-    "ts-jest": "^29.4.0",
+    "ts-jest": "^29.4.1",
     "ts-node-dev": "^2.0.0"
   }
 }

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -17,6 +17,6 @@ export class AuthController {
     const userData: RegisterDto = request.body;
     const newUser = await AuthService.register(userData);
 
-    response.status(201).json(success(newUser.id));
+    response.status(201).json(success(newUser.id, "Usuario creado"));
   }
 }

--- a/backend/src/utilities/success.utility.ts
+++ b/backend/src/utilities/success.utility.ts
@@ -1,3 +1,3 @@
-export function success(value: any) {
-  return { value };
+export function success(value: any, message?: string) {
+  return message ? { message, userId: value } : { value };
 }

--- a/backend/tests/mocks/env.mock.ts
+++ b/backend/tests/mocks/env.mock.ts
@@ -1,0 +1,5 @@
+export const envMock = {
+  JWT_SECRET: 'testsecret',
+  DATABASE_URL: 'mysql://localhost/testdb',
+  PORT: 3000
+};

--- a/backend/tests/unit/auth.middleware.test.ts
+++ b/backend/tests/unit/auth.middleware.test.ts
@@ -3,6 +3,7 @@ import { Response, NextFunction } from 'express';
 import { authMiddleware } from '../../src/middlewares/auth.middleware';
 
 import jwt, { TokenExpiredError } from 'jsonwebtoken';
+import { UnauthorizedError } from "../../src/models/unauthorized-error.model";
 
 
 jest.mock('jsonwebtoken');
@@ -36,11 +37,12 @@ describe('Auth Middleware', () => {
 
   it('should return 401 if authorization header is missing', () => {
     const req: any = { headers: {} };
-    authMiddleware(req, res as Response, next);
+   
+     expect(() => authMiddleware(req, {} as any, next))
+  .toThrow(UnauthorizedError);
 
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ message: 'No token provided' });
-    expect(next).not.toHaveBeenCalled();
+expect(() => authMiddleware(req, {} as any, next))
+  .toThrow("No token provided");
 
   });
 
@@ -50,14 +52,10 @@ describe('Auth Middleware', () => {
       throw new TokenExpiredError('Token expired', new Date());
     });
 
-    authMiddleware(req, res as Response, next);
-
-
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Token expired' });
-    expect(next).not.toHaveBeenCalled();
-
-
+      expect(() => authMiddleware(req, {} as any, next))
+    .toThrow( UnauthorizedError);
+  expect(() => authMiddleware(req, {} as any, next))
+  .toThrow("Token expired");
   });
 
   it("should return 401 if token is invalid", () => {
@@ -66,12 +64,11 @@ describe('Auth Middleware', () => {
       throw new Error("Invalid token");
     });
 
-    authMiddleware(req, res as Response, next);
+      expect(() => authMiddleware(req, {} as any, next))
+    .toThrow( UnauthorizedError);
+  expect(() => authMiddleware(req, {} as any, next))
+  .toThrow("Invalid token");
 
-
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid token' });
-    expect(next).not.toHaveBeenCalled();
 
 
   });

--- a/backend/tests/unit/auth.middleware.test.ts
+++ b/backend/tests/unit/auth.middleware.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Response, NextFunction } from 'express';
+import { authMiddleware } from '../../src/middlewares/auth.middleware';
+
+import jwt, { TokenExpiredError } from 'jsonwebtoken';
+
+
+jest.mock('jsonwebtoken');
+jest.mock('../../src/configuration/env.configuration', () => ({
+  ...require('../mocks/env.mock').envMock
+}));
+
+describe('Auth Middleware', () => {
+
+  let next: NextFunction;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    next = jest.fn();
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    } as unknown as Response;
+  });
+
+  it('should call next() if authorization header is present', () => {
+    const req: any = { headers: { authorization: 'Bearer validtoken' } };
+    (jwt.verify as jest.Mock).mockReturnValue({ userId: '123' });
+
+
+    authMiddleware(req, res as Response, next);
+
+    expect(req.user).toEqual({ id: "123" })
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should return 401 if authorization header is missing', () => {
+    const req: any = { headers: {} };
+    authMiddleware(req, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'No token provided' });
+    expect(next).not.toHaveBeenCalled();
+
+  });
+
+  it("should return 401 if token is expired", () => {
+    const req: any = { headers: { authorization: 'Bearer expiredtoken' } };
+    (jwt.verify as jest.Mock).mockImplementation(() => {
+      throw new TokenExpiredError('Token expired', new Date());
+    });
+
+    authMiddleware(req, res as Response, next);
+
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Token expired' });
+    expect(next).not.toHaveBeenCalled();
+
+
+  });
+
+  it("should return 401 if token is invalid", () => {
+    const req: any = { headers: { authorization: 'Bearer invalidtoken' } };
+    (jwt.verify as jest.Mock).mockImplementation(() => {
+      throw new Error("Invalid token");
+    });
+
+    authMiddleware(req, res as Response, next);
+
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid token' });
+    expect(next).not.toHaveBeenCalled();
+
+
+  });
+
+
+
+});

--- a/backend/tests/unit/auth.service.test.ts
+++ b/backend/tests/unit/auth.service.test.ts
@@ -10,6 +10,9 @@ import { bcryptMock } from "../mocks/bcrypt.mock";
 
 jest.mock("../../src/repositories/user.repository");
 jest.mock("bcrypt");
+jest.mock('../../src/configuration/env.configuration', () => ({
+  ...require('../mocks/env.mock').envMock
+}));
 
 describe("AuthService", () => {
   describe("login", () => {


### PR DESCRIPTION
Agrega pruebas unitarias para el middleware de autenticación (authMiddleware):

- Valida que next() se llame con token válido.
- Retorna 401 para:
  - Token ausente
  - Token expirado
  - Token inválido
- Usa mocks de Request, Response y NextFunction.
- Mock de `env.configuration` para simular variables de entorno en los tests.
