### PR TITLE
Cambiar respuestas de login y register

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -8,15 +8,15 @@ export class AuthController {
   static async login(request: Request, response: Response): Promise<void> {
     const { email, password } = request.body as LoginDto;
 
-    const authorization = await AuthService.login(email, password);
+    const loginData = await AuthService.login(email, password);
 
-    response.status(200).json(success(authorization));
+    response.status(200).json(success(loginData));
   }
 
   static async register(request: Request, response: Response): Promise<void> {
     const userData: RegisterDto = request.body;
-    const newUser = await AuthService.register(userData);
+    const registerData = await AuthService.register(userData);
 
-    response.status(201).json(success(newUser.id));
+    response.status(201).json(success(registerData));
   }
 }

--- a/backend/src/routers/auth.router.ts
+++ b/backend/src/routers/auth.router.ts
@@ -6,7 +6,9 @@ import { RegisterDto } from "../models/dtos/register.dto";
 
 export const AuthRouter = Router();
 
-AuthRouter.post("/login", dtoValidationMiddleware(LoginDto),
+AuthRouter.post(
+  "/login",
+  dtoValidationMiddleware(LoginDto),
   /*
   #swagger.path = '/login'
   #swagger.tags = ['Auth']
@@ -30,15 +32,16 @@ AuthRouter.post("/login", dtoValidationMiddleware(LoginDto),
   }
 
   #swagger.responses[200] = {
-    description: 'Returns JWT toke',
+    description: 'Returns JWT token and user data',
     content: {
       'application/json': {
         schema: {
           type: 'object',
           properties: {
-            value: { type: 'string', example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' }
+            authorization: { type: 'string', example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' },
+            user: { $ref: '#/components/schemas/User' }
           },
-          required: ['accessToken']
+          required: ['authorization', 'user']
         }
       }
     }
@@ -48,30 +51,8 @@ AuthRouter.post("/login", dtoValidationMiddleware(LoginDto),
     description: 'Invalid credentials',
     content: {
       'application/json': {
-        schema: {
-          type: 'object',
-          properties: {
-            error: { type: 'string', example: 'Invalid password' }
-          },
-          required: ['error']
-        },
+        schema: { type: 'object', properties: { error: { type: 'string', example: 'Invalid password' } }, required: ['error'] },
         example: { error: 'Invalid password' }
-      }
-    }
-  }
-
-  #swagger.responses[500] = {
-    description: 'Unexpected error',
-    content: {
-      'application/json': {
-        schema: {
-          type: 'object',
-          properties: {
-            error: { type: 'string', example: 'Unexpected error' }
-          },
-          required: ['error']
-        },
-        example: { error: 'Unexpected error' }
       }
     }
   }
@@ -80,103 +61,93 @@ AuthRouter.post("/login", dtoValidationMiddleware(LoginDto),
     description: 'User not found',
     content: {
       'application/json': {
-        schema: {
-          type: 'object',
-          properties: {
-            error: { type: 'string', example: 'User not found' }
-          },
-          required: ['error']
-        },
+        schema: { type: 'object', properties: { error: { type: 'string', example: 'User not found' } }, required: ['error'] },
         example: { error: 'User not found' }
       }
     }
   }
-*/
-  AuthController.login);
 
-  AuthRouter.post('/register', dtoValidationMiddleware(RegisterDto), 
-    /*
-    #swagger.path = '/register'
-    #swagger.tags = ['Auth']
-    #swagger.description = 'Creates new user'
-     #swagger.method = 'post'
-  
-    #swagger.requestBody = {
-      required: true,
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            required: ['name', 'email', 'password', 'image'],
-            properties: {
-              name: { type: 'string', example: 'Juan Pérez' },
-              email: { type: 'string', example: 'juan.perez@email.com' },
-              password: { type: 'string', example: 'Password123!' },
-              image: { type: 'string', example: 'https://example.com/avatar.jpg' }
-            }
+  #swagger.responses[500] = {
+    description: 'Unexpected error',
+    content: {
+      'application/json': {
+        schema: { type: 'object', properties: { error: { type: 'string', example: 'Unexpected error' } }, required: ['error'] },
+        example: { error: 'Unexpected error' }
+      }
+    }
+  }
+  */
+  AuthController.login
+);
+
+AuthRouter.post(
+  "/register",
+  dtoValidationMiddleware(RegisterDto),
+  /*
+  #swagger.path = '/register'
+  #swagger.tags = ['Auth']
+  #swagger.description = 'Creates new user and returns an authorization token'
+
+  #swagger.requestBody = {
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          required: ['name', 'email', 'password'],
+          properties: {
+            name: { type: 'string', example: 'Juan Pérez' },
+            email: { type: 'string', example: 'juan.perez@email.com' },
+            password: { type: 'string', example: 'Password123!' },
+            image: { type: 'string', example: 'https://example.com/avatar.jpg' }
           }
         }
       }
     }
-  
-    #swagger.responses[201] = {
-      description: 'User successfully created',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              value: { type: 'string', example: '507f1f77bcf86cd799439011' }
-            },
-            required: ['value']
-          }
+  }
+
+  #swagger.responses[201] = {
+    description: 'User successfully created and authenticated',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            authorization: { type: 'string', example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' },
+            user: { $ref: '#/components/schemas/User' }
+          },
+          required: ['authorization', 'user']
         }
       }
     }
-  
-    #swagger.responses[400] = {
-      description: 'Invalid credentials',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              error: { type: 'string', example: 'The password must be at least 8 characters long' }
-            },
-            required: ['error']
-          }
-        }
+  }
+
+  #swagger.responses[400] = {
+    description: 'Invalid input',
+    content: {
+      'application/json': {
+        schema: { type: 'object', properties: { error: { type: 'string', example: 'The password must be at least 8 characters long' } }, required: ['error'] }
       }
     }
-  
-    #swagger.responses[409] = {
-      description: 'Email already registered',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              error: { type: 'string', example: 'Email juan.perez@email.com is already registered' }
-            },
-            required: ['error']
-          }
-        }
+  }
+
+  #swagger.responses[409] = {
+    description: 'Email already registered',
+    content: {
+      'application/json': {
+        schema: { type: 'object', properties: { error: { type: 'string', example: 'Email juan.perez@email.com is already registered' } }, required: ['error'] }
       }
     }
-  
-    #swagger.responses[500] = {
-      description: 'Unexpected error',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              error: { type: 'string', example: 'Unexpected error' }
-            },
-            required: ['error']
-          }
-        }
+  }
+
+  #swagger.responses[500] = {
+    description: 'Unexpected error',
+    content: {
+      'application/json': {
+        schema: { type: 'object', properties: { error: { type: 'string', example: 'Unexpected error' } }, required: ['error'] }
       }
     }
-    */
-   AuthController.register);
+  }
+  */
+  AuthController.register
+);

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -19,14 +19,16 @@ export class AuthService {
 
     if (!passwordsMatches) throw new BadRequestError("Invalid password");
 
-    return this.getAuthorization(user.id);
+    const authorization = await this.getAuthorization(user.id);
+
+    return { user, authorization };
   }
 
   static async getAuthorization(userId: number | string) {
     return jwt.sign({ userId }, JWT_SECRET, { expiresIn: "1h" });
   }
 
-  static async register(data: RegisterDto): Promise<User> {
+  static async register(data: RegisterDto) {
     const existingUser = await UserRepository.getByEmail(data.email);
 
     if (existingUser) {
@@ -41,7 +43,8 @@ export class AuthService {
       image: data.image,
     });
 
-    return newUser;
+    const authorization = await this.getAuthorization(newUser.id);
+
+    return { user: newUser, authorization };
   }
 }
-

--- a/backend/tests/unit/auth.controller.test.ts
+++ b/backend/tests/unit/auth.controller.test.ts
@@ -8,7 +8,7 @@ jest.mock("../../src/services/auth.service");
 describe("AuthController", () => {
   describe("login", () => {
     it("should respond with 200 and token", async () => {
-      const jwtTokenMock = "fake-jwt-token";
+      const expected = { authorization: "fake-jwt-token", user: mockUser };
       const requestMock = {
         body: { email: "test@example.com", password: "123456" },
       } as any;
@@ -17,7 +17,7 @@ describe("AuthController", () => {
         json: jest.fn(),
       } as any;
 
-      authServiceMock.login.mockResolvedValue(jwtTokenMock);
+      authServiceMock.login.mockResolvedValue(expected);
       await AuthController.login(requestMock, responseMock);
 
       expect(authServiceMock.login).toHaveBeenCalledWith(
@@ -25,36 +25,33 @@ describe("AuthController", () => {
         requestMock.body.password
       );
       expect(responseMock.status).toHaveBeenCalledWith(200);
-      expect(responseMock.json).toHaveBeenCalledWith({ value: jwtTokenMock });
+      expect(responseMock.json).toHaveBeenCalledWith({ value: expected });
     });
   });
-});
 
-describe("register", () => {
-  it("should respond with 201 and new user ID", async () => {
-    const requestMock = {
-      body: {
-        name: "Test User",
-        email: "test@example.com",
-        password: "password123",
-      },
-    } as any;
+  describe("register", () => {
+    it("should respond with 201 and new user ID", async () => {
+      const expected = { authorization: "fake-jwt-token", user: mockUser };
+      const requestMock = {
+        body: {
+          name: "Test User",
+          email: "test@example.com",
+          password: "password123",
+        },
+      } as any;
 
-    const responseMock = {
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn(),
-    } as any;
+      const responseMock = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
 
-    const newUserMock = {
-      id: 1,
-    };
+      authServiceMock.register.mockResolvedValue(expected);
 
-    authServiceMock.register.mockResolvedValue(mockUser);
+      await AuthController.register(requestMock, responseMock);
 
-    await AuthController.register(requestMock, responseMock);
-
-    expect(authServiceMock.register).toHaveBeenCalledWith(requestMock.body);
-    expect(responseMock.status).toHaveBeenCalledWith(201);
-    expect(responseMock.json).toHaveBeenCalledWith({ value: newUserMock.id });
+      expect(authServiceMock.register).toHaveBeenCalledWith(requestMock.body);
+      expect(responseMock.status).toHaveBeenCalledWith(201);
+      expect(responseMock.json).toHaveBeenCalledWith({ value: expected });
+    });
   });
 });

--- a/backend/tests/unit/auth.service.test.ts
+++ b/backend/tests/unit/auth.service.test.ts
@@ -24,12 +24,14 @@ describe("AuthService", () => {
       userRepositoryMock.getByEmail.mockResolvedValue(mockUser);
       bcryptMock.compare.mockResolvedValue(true);
 
-      const authorization = await AuthService.login(
+      const result = await AuthService.login(
         mockUser.email,
         mockUser._unhashedPassword
       );
 
-      expect(typeof authorization).toBe("string");
+      expect(typeof result).toBe("object");
+      expect(result).toHaveProperty("authorization");
+      expect(result).toHaveProperty("user");
     });
 
     it("should throw a 'NotFoundError' when user not found", async () => {
@@ -97,8 +99,9 @@ describe("AuthService", () => {
         password: "hashedPassword123",
         image: data.image,
       });
-      expect(result).toHaveProperty("id");
-      expect(result.password).toBe("hashedPassword123");
+      expect(result).toHaveProperty("authorization");
+      expect(result).toHaveProperty("user");
+      expect(result.user.password).toBe("hashedPassword123");
     });
   });
 });


### PR DESCRIPTION
Esta rama modifica las respuestas de `login` y `register`, haciendo que ambos devuelvan un objeto con el token de autorización y el usuario correspondiente.

Esto tiene como objetivo que el usuario que consume estos endpoints obtenga el token necesario para autenticar futuras peticiones y el usuario correspondiente para no tener que obtenerlo en una petición aparte.

Como cambios consecuentes se modificaron los tests y documentación de `auth.service.ts` y `auth.controller.ts`