### PR TITLE
Arreglar error de CORS

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "cors": "^2.8.5",
         "express": "^5.1.0",
         "express-joi-validation": "^6.1.0",
         "joi": "^17.13.3",
@@ -27,6 +28,7 @@
       "devDependencies": {
         "@jest/globals": "^30.0.5",
         "@types/bcrypt": "^6.0.0",
+        "@types/cors": "^2.8.19",
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.3.0",
@@ -1496,6 +1498,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
@@ -2355,6 +2367,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-require": {
@@ -4629,6 +4654,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "express-joi-validation": "^6.1.0",
     "joi": "^17.13.3",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@jest/globals": "^30.0.5",
     "@types/bcrypt": "^6.0.0",
+    "@types/cors": "^2.8.19",
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.3.0",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,18 +6,13 @@ import { PORT } from "./configuration/env.configuration";
 import swaggerUi from "swagger-ui-express";
 import swaggerOutput from "../swagger_output.json";
 import { TransactionRouter } from "./routers/transaction.router";
+import { CORS_CONFIGURATION } from "./configuration/cors.configuration";
 
 export const app = express();
 
 app
   .disable("x-powered-by")
-  .use(
-    cors({
-      origin: ["http://localhost:5173"],
-      methods: ["GET", "POST", "PATCH", "DELETE"],
-      credentials: true,
-    })
-  )
+  .use(cors(CORS_CONFIGURATION))
   .use(jsonMiddleware())
   .use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerOutput))
   .use("/transactions", TransactionRouter)

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,3 +1,4 @@
+import cors from "cors";
 import { errorHandlerMiddleware } from "./middlewares/error-handler.middleware";
 import express, { json as jsonMiddleware } from "express";
 import { AuthRouter } from "./routers/auth.router";
@@ -10,6 +11,13 @@ export const app = express();
 
 app
   .disable("x-powered-by")
+  .use(
+    cors({
+      origin: ["http://localhost:5173"],
+      methods: ["GET", "POST", "PATCH", "DELETE"],
+      credentials: true,
+    })
+  )
   .use(jsonMiddleware())
   .use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerOutput))
   .use("/transactions", TransactionRouter)

--- a/backend/src/configuration/cors.configuration.ts
+++ b/backend/src/configuration/cors.configuration.ts
@@ -1,0 +1,7 @@
+import { CorsOptions } from "cors";
+
+export const CORS_CONFIGURATION: CorsOptions = {
+  origin: ["http://localhost:5173"],
+  methods: ["GET", "POST", "PATCH", "DELETE"],
+  credentials: true,
+};


### PR DESCRIPTION
Esta rama arregla el error de CORS permitiendo al frontend usar la API mediante el middleware `cors` usado en `app.ts`.
Además se creó `cors.configuration.ts` para separar de `app.ts` la configuración de CORS.