### PR TITLE
[HU-BE07] Añadir endpoint de obtención de transacción

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,4 +1,4 @@
-import cors from "cors";
+import corsMiddleware from "cors";
 import { errorHandlerMiddleware } from "./middlewares/error-handler.middleware";
 import express, { json as jsonMiddleware } from "express";
 import { AuthRouter } from "./routers/auth.router";
@@ -12,7 +12,7 @@ export const app = express();
 
 app
   .disable("x-powered-by")
-  .use(cors(CORS_CONFIGURATION))
+  .use(corsMiddleware(CORS_CONFIGURATION))
   .use(jsonMiddleware())
   .use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerOutput))
   .use("/transactions", TransactionRouter)

--- a/backend/src/controllers/transaction.controller.ts
+++ b/backend/src/controllers/transaction.controller.ts
@@ -3,12 +3,31 @@ import { TransactionRepository } from "../repositories/transaction.repository";
 import { success } from "../utilities/success.utility";
 import { TransactionService } from "../services/transaction.service";
 import { AuthenticatedRequest } from "../models/authenticated-request.model";
+import { BadRequestError } from "../models/errors/bad-request.error";
+import { UnauthorizedError } from "../models/errors/unauthorized.error";
 
 export class TransactionController {
   static async getAll(_request: Request, response: Response): Promise<void> {
     const transactions = await TransactionRepository.getAll();
 
     response.json(success(transactions));
+  }
+
+  static async getById(request: Request, response: Response): Promise<void> {
+    const { user } = request as AuthenticatedRequest;
+    const { id } = request.params;
+
+    if (!id) throw new BadRequestError("Transaction ID is missing");
+
+    const transactionId = Number(id);
+
+    if (isNaN(transactionId)) throw new BadRequestError("Invalid Transaction ID");
+
+    const transaction = await TransactionService.getById(transactionId);
+
+    if (user.id !== transaction.userId) throw new UnauthorizedError("Unauthorized");
+
+    response.json(success(transaction));
   }
 
   static async create(request: Request, response: Response): Promise<void> {

--- a/backend/src/routers/transaction.router.ts
+++ b/backend/src/routers/transaction.router.ts
@@ -7,6 +7,75 @@ import { dtoValidationMiddleware } from "../middlewares/dto-validation.middlewar
 export const TransactionRouter = Router();
 
 TransactionRouter.get(
+  "/:id",
+  authMiddleware,
+  /*
+  #swagger.path = '/transactions/:id'
+  #swagger.tags = ['Transactions']
+  #swagger.description = 'Returns a transaction'
+
+  #swagger.parameters['id'] = { description: 'Id of the transaction to get' }
+
+  #swagger.responses[200] = {
+    description: 'A transaction',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            value: { $ref: '#/components/schemas/Transaction' }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  #swagger.responses[400] = {
+    description: 'Transaction ID is missing',
+    content: {
+      'application/json': {
+        schema: { type: 'object', properties: { error: { type: 'string' } } },
+        example: { error: 'Transaction ID is missing' }
+      }
+    }
+  }
+
+  #swagger.responses[400] = {
+    description: 'Invalid transaction ID',
+    content: {
+      'application/json': {
+        schema: { type: 'object', properties: { error: { type: 'string' } } },
+        example: { error: 'Invalid transaction ID' }
+      }
+    }
+  }
+
+  #swagger.responses[404] = {
+    description: 'Transaction not found',
+    content: {
+      'application/json': {
+        schema: { type: 'object', properties: { error: { type: 'string' } } },
+        example: { error: 'Transaction not found' }
+      }
+    }
+  }
+
+  #swagger.responses[401] = {
+    description: 'Unauthorized',
+    content: {
+      'application/json': {
+        schema: { type: 'object', properties: { error: { type: 'string' } } },
+        example: { error: 'Unauthorized' }
+      }
+    }
+  }
+    
+  */
+  TransactionController.getById
+);
+
+TransactionRouter.get(
   "/",
   authMiddleware,
   /*

--- a/backend/src/services/transaction.service.ts
+++ b/backend/src/services/transaction.service.ts
@@ -28,4 +28,12 @@ export class TransactionService {
 
     await TransactionRepository.delete(transactionId);
   }
+
+  static async getById(id: number): Promise<Transaction> {
+    const transaction = await TransactionRepository.getById(id);
+
+    if (!transaction) throw new NotFoundError("Transaction not found");
+
+    return transaction;
+  }
 }

--- a/backend/tests/unit/transaction.controller.test.ts
+++ b/backend/tests/unit/transaction.controller.test.ts
@@ -1,6 +1,9 @@
+import { transactionMock } from "./../mocks/transaction.mock";
 import { TransactionController } from "./../../src/controllers/transaction.controller";
 import { transactionServiceMock } from "./../mocks/transaction.service.mock";
 import { describe, expect, it, jest } from "@jest/globals";
+import { BadRequestError } from "../../src/models/errors/bad-request.error";
+import { UnauthorizedError } from "../../src/models/errors/unauthorized.error";
 
 jest.mock("../../src/services/transaction.service");
 
@@ -25,6 +28,60 @@ describe("TransactionController", () => {
       );
       expect(responseMock.status).toHaveBeenCalledWith(204);
       expect(responseMock.end).toHaveBeenCalled();
+    });
+  });
+
+  describe("getById", () => {
+    it("should return a transaction with the given ID", async () => {
+      const requestMock = {
+        user: { id: transactionMock.userId },
+        params: { id: transactionMock.id },
+      } as any;
+      const responseMock = { json: jest.fn() } as any;
+      const getByIdSpy = jest
+        .spyOn(transactionServiceMock, "getById")
+        .mockResolvedValue(transactionMock);
+
+      await TransactionController.getById(requestMock, responseMock);
+
+      expect(getByIdSpy).toHaveBeenCalledWith(requestMock.params.id);
+      expect(responseMock.json).toHaveBeenCalled();
+    });
+
+    it("should throw a 'BadRequestError' when transaction ID is missing", async () => {
+      const requestMock = {
+        user: { id: transactionMock.userId },
+        params: {},
+      } as any;
+      const responseMock = {} as any;
+
+      await expect(
+        TransactionController.getById(requestMock, responseMock)
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw a 'BadRequestError' when transaction ID is invalid", async () => {
+      const requestMock = {
+        user: { id: transactionMock.userId },
+        params: { id: "abc" },
+      } as any;
+      const responseMock = {} as any;
+
+      await expect(
+        TransactionController.getById(requestMock, responseMock)
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it("should throw a 'UnauthorizedError' when trying to access a transaction of another user", async () => {
+      const requestMock = {
+        user: { id: 2 },
+        params: { id: transactionMock.id },
+      } as any;
+      const responseMock = {} as any;
+
+      await expect(
+        TransactionController.getById(requestMock, responseMock)
+      ).rejects.toThrow(UnauthorizedError);
     });
   });
 });

--- a/backend/tests/unit/transaction.service.test.ts
+++ b/backend/tests/unit/transaction.service.test.ts
@@ -48,4 +48,31 @@ describe("TransactionService", () => {
       ).rejects.toThrow(UnauthorizedError);
     });
   });
+
+  describe("getById", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should return a transaction with the given id", async () => {
+      const { id } = transactionMock;
+      const getByIdSpy = jest
+        .spyOn(transactionRepositoryMock, "getById")
+        .mockResolvedValue(transactionMock);
+
+      const result = await TransactionService.getById(id);
+
+      expect(result).toEqual(transactionMock);
+      expect(getByIdSpy).toHaveBeenCalledWith(id);
+    });
+
+    it("should throw a 'NotFoundError' when transaction not found", async () => {
+      const id = 1;
+      transactionRepositoryMock.getById.mockResolvedValue(null);
+
+      await expect(TransactionService.getById(id)).rejects.toThrow(
+        NotFoundError
+      );
+    });
+  });
 });


### PR DESCRIPTION
Esta rama añade el endpoint de obtención de una única transacción.
Los cambios son:

- **Router:** Se añadió el endpoint `GET /transactions/:id.
- **Controller:** Se creó el método `getById` que extrae el parámetro `id` de la request. Tiene validaciones para IDs faltante o inválida, y para que solo se pueda obtener una transacción que te pertenece.
- **Service:** Recibe el `id` y usa 