### PR TITLE
Arreglar bug de paginación

### DIFF
--- a/backend/src/controllers/transaction.controller.ts
+++ b/backend/src/controllers/transaction.controller.ts
@@ -8,28 +8,31 @@ import { transactionFiltersSchema } from "../models/schemas/transaction-filters.
 import { CreateTransactionDto } from "../models/dtos/create-transaction.dto";
 import { paginationQuerySchema } from "../models/schemas/pagination-query.schema";
 import { PaginationQuery } from "../models/pagination-query.model";
-import {UpdateTransactionDto } from "../models/dtos/update-transaction.dto";
+import { UpdateTransactionDto } from "../models/dtos/update-transaction.dto";
 
 export class TransactionController {
   static async getAllOfUser(
     request: Request,
     response: Response
   ): Promise<void> {
-    const { error: paginationError, value: paginationQuery } = paginationQuerySchema.validate(request.query)
+    const { error: paginationError, value: paginationQuery } =
+      paginationQuerySchema.validate(request.query);
 
     if (paginationError) throw new BadRequestError(paginationError.message);
-    
-    const { error: filtersError, value: filters } = transactionFiltersSchema.validate(request.query);
+
+    const { error: filtersError, value: filters } =
+      transactionFiltersSchema.validate(request.query);
 
     if (filtersError) throw new BadRequestError(filtersError.message);
 
-    const { page, amount } = paginationQuery as PaginationQuery
+    const { page, limit } = paginationQuery as PaginationQuery;
+
     const authenticatedRequest = request as AuthenticatedRequest;
     const userId = authenticatedRequest.user.id;
     const paginatedTransactions = await TransactionService.getAllOfUser({
       userId,
       page,
-      amount,
+      limit,
       filters,
     });
 
@@ -58,7 +61,10 @@ export class TransactionController {
   static async create(request: Request, response: Response): Promise<void> {
     const { user } = request as AuthenticatedRequest;
     const createTransactionDto = request.body as CreateTransactionDto;
-    const newTransaction = await TransactionService.create(createTransactionDto, user.id);
+    const newTransaction = await TransactionService.create(
+      createTransactionDto,
+      user.id
+    );
 
     response.status(201).json(success(newTransaction));
   }
@@ -67,17 +73,20 @@ export class TransactionController {
     const { user } = request as AuthenticatedRequest;
     const updateTransactionDto = request.body as UpdateTransactionDto;
     const { id } = request.params;
-     if (!id) {
-    throw new BadRequestError("Transaction ID is missing");
-  }
+    if (!id) {
+      throw new BadRequestError("Transaction ID is missing");
+    }
 
-  const transactionId = Number(id);
-  if (isNaN(transactionId)) {
-    throw new BadRequestError("Invalid Transaction ID");
-  }
+    const transactionId = Number(id);
+    if (isNaN(transactionId)) {
+      throw new BadRequestError("Invalid Transaction ID");
+    }
 
- 
-    const updateTransaction  = await TransactionService.update(transactionId,user.id,updateTransactionDto);
+    const updateTransaction = await TransactionService.update(
+      transactionId,
+      user.id,
+      updateTransactionDto
+    );
 
     response.status(200).json(success(updateTransaction));
   }

--- a/backend/src/models/pagination-query.model.ts
+++ b/backend/src/models/pagination-query.model.ts
@@ -1,1 +1,1 @@
-export type PaginationQuery = { page: number; amount: number };
+export type PaginationQuery = { page: number; limit: number };

--- a/backend/src/models/schemas/pagination-query.schema.ts
+++ b/backend/src/models/schemas/pagination-query.schema.ts
@@ -2,5 +2,5 @@ import Joi from "joi";
 
 export const paginationQuerySchema = Joi.object({
   page: Joi.number().default(1),
-  amount: Joi.number().default(8),
+  limit: Joi.number().default(8),
 }).unknown(true);

--- a/backend/src/repositories/transaction.repository.ts
+++ b/backend/src/repositories/transaction.repository.ts
@@ -8,13 +8,13 @@ export class TransactionRepository {
   static async getAllOfUser(args: {
     userId: number;
     skip: number;
-    amount: number;
+    limit: number;
     filters: Prisma.TransactionWhereInput;
   }): Promise<Transaction[]> {
     return await prisma.transaction.findMany({
       where: { userId: args.userId, ...args.filters },
       skip: args.skip,
-      take: args.amount,
+      take: args.limit,
       orderBy: { date: "desc" },
     });
   }

--- a/backend/src/routers/transaction.router.ts
+++ b/backend/src/routers/transaction.router.ts
@@ -93,7 +93,7 @@ TransactionRouter.get(
     example: 1
   }
 
-  #swagger.parameters['amount'] = {
+  #swagger.parameters['limit'] = {
     in: 'query',
     description: 'Number of transactions per page',
     required: false,

--- a/backend/src/services/transaction.service.ts
+++ b/backend/src/services/transaction.service.ts
@@ -33,7 +33,7 @@ export class TransactionService {
     const transactions = await TransactionRepository.getAllOfUser({
       userId: args.userId,
       skip,
-      amount: queryAmount,
+      limit: queryAmount,
       filters,
     });
     const hasNextPage = transactions.length > requestedAmount;

--- a/backend/src/services/transaction.service.ts
+++ b/backend/src/services/transaction.service.ts
@@ -22,10 +22,10 @@ export class TransactionService {
   static async getAllOfUser(args: {
     userId: number;
     page: number;
-    amount: number;
+    limit: number;
     filters?: TransactionFilters;
   }): Promise<PaginatedResult<Transaction>> {
-    const requestedAmount = args.amount;
+    const requestedAmount = args.limit;
     const queryAmount = requestedAmount + 1;
     const currentPage = args.page < 1 ? 1 : args.page;
     const skip = (currentPage - 1) * requestedAmount;

--- a/backend/swagger_output.json
+++ b/backend/swagger_output.json
@@ -515,7 +515,7 @@
             }
           },
           {
-            "name": "amount",
+            "name": "limit",
             "in": "query",
             "description": "Number of transactions per page",
             "required": false,

--- a/backend/tests/unit/transaction.controller.test.ts
+++ b/backend/tests/unit/transaction.controller.test.ts
@@ -72,7 +72,7 @@ describe("TransactionController", () => {
         query: { page: 1, amount: 2 },
       } as any;
       const responseMock = { json: jest.fn() } as any;
-      const paginationQuery: PaginationQuery = { amount: 2, page: 1 };
+      const paginationQuery: PaginationQuery = { limit: 2, page: 1 };
       const filters = {};
 
       jest
@@ -90,7 +90,7 @@ describe("TransactionController", () => {
       expect(transactionServiceMock.getAllOfUser).toHaveBeenCalledWith({
         userId: requestMock.user.id,
         page: paginationQuery.page,
-        amount: paginationQuery.amount,
+        limit: paginationQuery.limit,
         filters,
       });
       expect(responseMock.json).toHaveBeenCalledWith({ value: serviceResult });

--- a/backend/tests/unit/transaction.service.test.ts
+++ b/backend/tests/unit/transaction.service.test.ts
@@ -82,7 +82,7 @@ describe("TransactionService", () => {
     });
 
     it("should return paginated transactions with hasNextPage false", async () => {
-      const args = { userId: 1, page: 1, amount: 2, filters: {} };
+      const args = { userId: 1, page: 1, limit: 2, filters: {} };
       jest
         .spyOn(transactionRepositoryMock, "getAllOfUser")
         .mockResolvedValue([transactionMock]);
@@ -92,14 +92,14 @@ describe("TransactionService", () => {
       expect(transactionRepositoryMock.getAllOfUser).toHaveBeenCalledWith({
         userId: args.userId,
         skip: 0,
-        amount: args.amount + 1,
+        limit: args.limit + 1,
         filters: args.filters,
       });
       expect(result).toEqual({ data: [transactionMock], hasNextPage: false });
     });
 
     it("should return hasNextPage true when there are more transactions than requested", async () => {
-      const args = { userId: 1, page: 1, amount: 1, filters: {} };
+      const args = { userId: 1, page: 1, limit: 1, filters: {} };
       const extraTransaction = { ...transactionMock, id: 2 };
       jest
         .spyOn(transactionRepositoryMock, "getAllOfUser")
@@ -110,14 +110,14 @@ describe("TransactionService", () => {
       expect(transactionRepositoryMock.getAllOfUser).toHaveBeenCalledWith({
         userId: args.userId,
         skip: 0,
-        amount: args.amount + 1,
+        limit: args.limit + 1,
         filters: args.filters,
       });
       expect(result).toEqual({ data: [transactionMock], hasNextPage: true });
     });
 
     it("should default page to 1 if page is less than 1", async () => {
-      const args = { userId: 1, page: 0, amount: 2, filters: {} };
+      const args = { userId: 1, page: 0, limit: 2, filters: {} };
       jest
         .spyOn(transactionRepositoryMock, "getAllOfUser")
         .mockResolvedValue([transactionMock]);


### PR DESCRIPTION
Esta rama arregla un conflicto que ocurría entre los query params de filtrado y paginación en el endpoint de obtención de transacciones.
Para solucionarlo, se cambió el nombre de "amount" a "limit", evitando el conflicto.