### PR TITLE
[HU-BE10] Añadir endpoint de resúmen financiero

### DIFF
--- a/backend/src/controllers/transaction.controller.ts
+++ b/backend/src/controllers/transaction.controller.ts
@@ -100,4 +100,11 @@ export class TransactionController {
 
     response.status(204).end();
   }
+
+  static async getSummary(request: Request, response: Response): Promise<void> {
+    const { user } = request as AuthenticatedRequest;
+    const summary = await TransactionService.getSummary(user.id);
+
+    response.status(200).json(success(summary));
+  }
 }

--- a/backend/src/repositories/transaction.repository.ts
+++ b/backend/src/repositories/transaction.repository.ts
@@ -4,7 +4,6 @@ import { CreateTransactionDto } from "../models/dtos/create-transaction.dto";
 import { UpdateTransactionDto } from "../models/dtos/update-transaction.dto";
 
 export class TransactionRepository {
- 
   static async getAllOfUser(args: {
     userId: number;
     skip: number;
@@ -44,19 +43,121 @@ export class TransactionRepository {
     }
   }
 
-   static async update(transactionId: number,    
-     updates: UpdateTransactionDto) : Promise<Transaction>{
-      
-      return await prisma.transaction.update({ 
-        where: { id:transactionId },
-        data:updates,
-      
-      });
-    
+  static async update(
+    transactionId: number,
+    updates: UpdateTransactionDto
+  ): Promise<Transaction> {
+    return await prisma.transaction.update({
+      where: { id: transactionId },
+      data: updates,
+    });
   }
- 
 
   static async delete(id: number): Promise<Transaction> {
     return await prisma.transaction.delete({ where: { id } });
+  }
+
+  static async getTotalExpenses(userId: number): Promise<number> {
+    const result = await prisma.transaction.aggregate({
+      _sum: {
+        amount: true,
+      },
+      where: {
+        userId,
+        type: "EXPENSE",
+      },
+    });
+
+    return result._sum.amount ?? 0;
+  }
+
+  static async getTotalIncomes(userId: number): Promise<number> {
+    const result = await prisma.transaction.aggregate({
+      _sum: {
+        amount: true,
+      },
+      where: {
+        userId,
+        type: "INCOME",
+      },
+    });
+
+    return result._sum.amount ?? 0;
+  }
+
+  static async getTodayExpenses(userId: number) {
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    const end = new Date();
+    end.setHours(23, 59, 59, 999);
+
+    const result = await prisma.transaction.aggregate({
+      _sum: { amount: true },
+      where: {
+        userId,
+        type: "EXPENSE",
+        date: {
+          gte: start,
+          lte: end,
+        },
+      },
+    });
+
+    return result._sum.amount ?? 0;
+  }
+
+  static async getWeekExpenses(userId: number) {
+    const now = new Date();
+    const dayOfWeek = now.getDay();
+    const diff = now.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
+
+    const start = new Date(now.setDate(diff));
+    start.setHours(0, 0, 0, 0);
+
+    const end = new Date(start);
+    end.setDate(start.getDate() + 6);
+    end.setHours(23, 59, 59, 999);
+
+    const result = await prisma.transaction.aggregate({
+      _sum: { amount: true },
+      where: {
+        userId,
+        type: "EXPENSE",
+        date: {
+          gte: start,
+          lte: end,
+        },
+      },
+    });
+
+    return result._sum.amount ?? 0;
+  }
+
+  static async getMonthExpenses(userId: number) {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    const end = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+      23,
+      59,
+      59,
+      999
+    );
+
+    const result = await prisma.transaction.aggregate({
+      _sum: { amount: true },
+      where: {
+        userId,
+        type: "EXPENSE",
+        date: {
+          gte: start,
+          lte: end,
+        },
+      },
+    });
+
+    return result._sum.amount ?? 0;
   }
 }

--- a/backend/src/routers/transaction.router.ts
+++ b/backend/src/routers/transaction.router.ts
@@ -10,6 +10,72 @@ export const TransactionRouter = Router();
 TransactionRouter.get(
   "/summary",
   authMiddleware,
+  /*
+  #swagger.path = '/transactions/summary'
+  #swagger.tags = ['Transactions']
+  #swagger.description = 'Returns a summary of transactions'
+  #swagger.security = [{ "bearerAuth": [] }]
+
+  #swagger.responses[200] = {
+    description: 'Summary of transactions',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            value: {
+              type: 'object',
+              properties: {
+                totalExpenses: {
+                  type: 'number',
+                  example: 20000
+                },
+                totalIncomes: {
+                  type: 'number',
+                  example: 0
+                },
+                monthBalance: {
+                  type: 'number',
+                  example: -20000
+                },
+                todayExpenses: {
+                  type: 'number',
+                  example: 0
+                },
+                weekExpenses: {
+                  type: 'number',
+                  example: 0
+                },
+                monthExpenses: {
+                  type: 'number',
+                  example: 5000
+                }
+              },
+              required: ['totalExpenses']
+            }
+          },
+          required: ['value']
+        }
+      }
+    }
+  }
+
+  #swagger.responses[500] = {
+    description: 'Unexpected error',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            error: { type: 'string', example: 'Unexpected error' }
+          },
+          required: ['error']
+        },
+        example: { error: 'Unexpected error' }
+      }
+    }
+  }
+  */
   TransactionController.getSummary
 );
 

--- a/backend/src/routers/transaction.router.ts
+++ b/backend/src/routers/transaction.router.ts
@@ -3,9 +3,15 @@ import { TransactionController } from "../controllers/transaction.controller";
 import { authMiddleware } from "../middlewares/auth.middleware";
 import { CreateTransactionDto } from "../models/dtos/create-transaction.dto";
 import { dtoValidationMiddleware } from "../middlewares/dto-validation.middleware";
-import{UpdateTransactionDto} from "../models/dtos/update-transaction.dto"
+import { UpdateTransactionDto } from "../models/dtos/update-transaction.dto";
 
 export const TransactionRouter = Router();
+
+TransactionRouter.get(
+  "/summary",
+  authMiddleware,
+  TransactionController.getSummary
+);
 
 TransactionRouter.get(
   "/:id",
@@ -289,7 +295,6 @@ TransactionRouter.patch(
   */
   TransactionController.update
 );
-
 
 TransactionRouter.delete(
   "/:id",

--- a/backend/src/services/transaction.service.ts
+++ b/backend/src/services/transaction.service.ts
@@ -6,7 +6,7 @@ import { PaginatedResult } from "../models/paginated-result.model";
 import { buildFilters } from "../utilities/build-filters.utility";
 import { TransactionFilters } from "../models/transaction-filters.model";
 import { CreateTransactionDto } from "../models/dtos/create-transaction.dto";
-import {UpdateTransactionDto} from "../models/dtos/update-transaction.dto";
+import { UpdateTransactionDto } from "../models/dtos/update-transaction.dto";
 
 export class TransactionService {
   static async create(
@@ -43,19 +43,17 @@ export class TransactionService {
   }
 
   static async update(
-    transactionId:number,
-     userId:number,
-       data: UpdateTransactionDto): Promise<Transaction> {
+    transactionId: number,
+    userId: number,
+    data: UpdateTransactionDto
+  ): Promise<Transaction> {
     const transaction = await TransactionRepository.getById(transactionId);
-   
+
     if (!transaction) throw new NotFoundError("Transaction not found");
     if (transaction.userId !== userId)
       throw new UnauthorizedError("This transaction doesn't belong to you");
 
-    return await TransactionRepository.update(transactionId,data);
-    
-      
-
+    return await TransactionRepository.update(transactionId, data);
   }
 
   static async delete(transactionId: number, userId: number): Promise<void> {
@@ -63,7 +61,6 @@ export class TransactionService {
 
     if (!transaction) throw new NotFoundError("Transaction not found");
     if (transaction.userId !== userId)
-     
       throw new UnauthorizedError("This transaction doesn't belong to you");
 
     await TransactionRepository.delete(transactionId);
@@ -75,5 +72,23 @@ export class TransactionService {
     if (!transaction) throw new NotFoundError("Transaction not found");
 
     return transaction;
+  }
+
+  static async getSummary(userId: number) {
+    const totalExpenses = await TransactionRepository.getTotalExpenses(userId);
+    const totalIncomes = await TransactionRepository.getTotalIncomes(userId);
+    const todayExpenses = await TransactionRepository.getTodayExpenses(userId);
+    const weekExpenses = await TransactionRepository.getWeekExpenses(userId);
+    const monthExpenses = await TransactionRepository.getMonthExpenses(userId);
+    const monthBalance = totalIncomes - totalExpenses;
+
+    return {
+      totalExpenses,
+      totalIncomes,
+      monthBalance,
+      todayExpenses,
+      weekExpenses,
+      monthExpenses,
+    };
   }
 }

--- a/backend/swagger_output.json
+++ b/backend/swagger_output.json
@@ -254,6 +254,90 @@
         }
       }
     },
+    "/transactions/summary": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "description": "Returns a summary of transactions",
+        "responses": {
+          "200": {
+            "description": "Summary of transactions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "object",
+                      "properties": {
+                        "totalExpenses": {
+                          "type": "number",
+                          "example": 20000
+                        },
+                        "totalIncomes": {
+                          "type": "number",
+                          "example": 0
+                        },
+                        "monthBalance": {
+                          "type": "number",
+                          "example": -20000
+                        },
+                        "todayExpenses": {
+                          "type": "number",
+                          "example": 0
+                        },
+                        "weekExpenses": {
+                          "type": "number",
+                          "example": 0
+                        },
+                        "monthExpenses": {
+                          "type": "number",
+                          "example": 5000
+                        }
+                      },
+                      "required": [
+                        "totalExpenses"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Unexpected error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                },
+                "example": {
+                  "error": "Unexpected error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
     "/transactions/{id}": {
       "get": {
         "tags": [

--- a/backend/tests/unit/transaction.controller.test.ts
+++ b/backend/tests/unit/transaction.controller.test.ts
@@ -125,4 +125,37 @@ describe("TransactionController", () => {
       ).rejects.toThrow(BadRequestError);
     });
   });
+
+  describe("getSummary", () => {
+    it("should return a summary of transactions", async () => {
+      const requestMock = { user: { id: 1 } } as any;
+      const json = jest.fn();
+      const responseMock = {
+        status: jest.fn().mockReturnValue({ json }),
+        json,
+      } as any;
+      const expected = {
+        totalExpenses: 20000,
+        totalIncomes: 0,
+        monthBalance: -20000,
+        todayExpenses: 0,
+        weekExpenses: 0,
+        monthExpenses: 5000,
+      };
+
+      transactionServiceMock.getSummary.mockResolvedValue(expected);
+      await TransactionController.getSummary(
+        requestMock,
+        responseMock
+      );
+
+      expect(transactionServiceMock.getSummary).toHaveBeenCalledWith(
+        requestMock.user.id
+      );
+      expect(responseMock.status).toHaveBeenCalledWith(200);
+      expect(responseMock.status().json).toHaveBeenCalledWith({
+        value: expected,
+      });
+    });
+  });
 });

--- a/backend/tests/unit/transaction.service.test.ts
+++ b/backend/tests/unit/transaction.service.test.ts
@@ -167,9 +167,9 @@ describe("TransactionService", () => {
       });
 
       const updated = await TransactionService.update(
-        mockTransaction.id, // transactionId
-        mockTransaction.userId, // userId correcto
-        updates // DTO de actualización
+        mockTransaction.id,
+        mockTransaction.userId,
+        updates
       );
 
       expect(updated.amount).toBe(6000);
@@ -206,6 +206,47 @@ describe("TransactionService", () => {
           date: new Date(),
         })
       ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("getSummary", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should return a summary of transactions", async () => {
+      const userId = 1;
+      const getTotalExpensesSpy = jest
+        .spyOn(transactionRepositoryMock, "getTotalExpenses")
+        .mockResolvedValue(20000);
+      const getTotalIncomesSpy = jest
+        .spyOn(transactionRepositoryMock, "getTotalIncomes")
+        .mockResolvedValue(0);
+      const getTodayExpensesSpy = jest
+        .spyOn(transactionRepositoryMock, "getTodayExpenses")
+        .mockResolvedValue(0);
+      const getWeekExpensesSpy = jest
+        .spyOn(transactionRepositoryMock, "getWeekExpenses")
+        .mockResolvedValue(0);
+      const getMonthExpensesSpy = jest
+        .spyOn(transactionRepositoryMock, "getMonthExpenses")
+        .mockResolvedValue(5000);
+
+      const result = await TransactionService.getSummary(userId);
+
+      expect(result).toEqual({
+        totalExpenses: 20000,
+        totalIncomes: 0,
+        monthBalance: -20000,
+        todayExpenses: 0,
+        weekExpenses: 0,
+        monthExpenses: 5000,
+      });
+      expect(getTotalExpensesSpy).toHaveBeenCalledWith(userId);
+      expect(getTotalIncomesSpy).toHaveBeenCalledWith(userId);
+      expect(getTodayExpensesSpy).toHaveBeenCalledWith(userId);
+      expect(getWeekExpensesSpy).toHaveBeenCalledWith(userId);
+      expect(getMonthExpensesSpy).toHaveBeenCalledWith(userId);
     });
   });
 });


### PR DESCRIPTION
Esta rama añade el endpoint de resúmen financiero. Los cambios son:

**✅ Endpoint:** Añadido el endpoint `/transactions/summary`, con middleware de autenticació.
**✅ Controlador:** Añadido el método `getSummary`, que maneja la petición y devuelve el resúmen financiero usando `TransactionService`.
**✅ Servicio:** Añadido el método `getSummary`, que realiza los calculos del resúmen financiero usando `TransactionRepository`.
**✅ Repositorio:** Añadido los métodos `getTotalExpenses`, `getTotalIncomes`, `getTodayExpenses`, `getWeekExpenses` y `getMonthExpenses`, que usan `prisma` para manejar los datos individualmente. Cada uno, en caso de no haber datos, devuelve 0.
**✅ Tests:** Añadido los tests de los métodos `getSummary` del controlador y del servicio.
**✅ Documentación:** Añadida la documentación del endpoint.